### PR TITLE
feat: save content before making preview build

### DIFF
--- a/apps/gatsby/package-lock.json
+++ b/apps/gatsby/package-lock.json
@@ -2241,9 +2241,9 @@
 			}
 		},
 		"@gatsby-cloud-pkg/gatsby-cms-extension-base": {
-			"version": "0.0.47",
-			"resolved": "https://registry.npmjs.org/@gatsby-cloud-pkg/gatsby-cms-extension-base/-/gatsby-cms-extension-base-0.0.47.tgz",
-			"integrity": "sha512-oS4wXQgYwc5GSC0CrUkJsnHK2QffBJmFBm7qG/4zMc4B55by+RWtUH86ZL8cOYh3LSXwXKZgXSaWjVwmIEO5fQ==",
+			"version": "0.0.48",
+			"resolved": "https://registry.npmjs.org/@gatsby-cloud-pkg/gatsby-cms-extension-base/-/gatsby-cms-extension-base-0.0.48.tgz",
+			"integrity": "sha512-BBk3bGvSfMIrbZmQ6jHRUxdrWjSlNPcwOKpjD9FCYDQCV+T+5xTx10FUWCp8ToobqkC/NYmPQLVunxE06KgQ5A==",
 			"requires": {
 				"@emotion/core": "^10.0.10",
 				"@emotion/styled": "^10.0.12"

--- a/apps/gatsby/package.json
+++ b/apps/gatsby/package.json
@@ -14,7 +14,7 @@
     "@contentful/forma-36-fcss": "0.3.3",
     "@contentful/forma-36-react-components": "3.93.2",
     "@contentful/forma-36-tokens": "0.11.0",
-    "@gatsby-cloud-pkg/gatsby-cms-extension-base": "0.0.47",
+    "@gatsby-cloud-pkg/gatsby-cms-extension-base": "0.0.48",
     "emotion": "10.0.14",
     "prop-types": "15.7.2",
     "react": "16.8.6",

--- a/apps/gatsby/src/Sidebar.js
+++ b/apps/gatsby/src/Sidebar.js
@@ -250,7 +250,7 @@ export default class Sidebar extends React.Component {
                  * ensure that the preview tab has the correct manifest id
                  * just in case the timing was slight off and it was opened with the wrong manifest id
                  */
-                previewWindow.location = this.getPreviewUrl();
+                previewWindow.location.href = this.getPreviewUrl();
               }}
             /> :
             <HelpText style={STATUS_STYLE}>

--- a/apps/gatsby/src/Sidebar.js
+++ b/apps/gatsby/src/Sidebar.js
@@ -247,8 +247,10 @@ export default class Sidebar extends React.Component {
               onOpenPreviewButtonClick={async ({ previewWindow }) => {
                 await this.refreshPreview();
                 /**
-                 * ensure that the preview tab has the correct manifest id
-                 * just in case the timing was slight off and it was opened with the wrong manifest id
+                 * ExtensionUI returns a reference to the opened tab (previewWindow) after eagerly
+                 * opening it with the given previewUrl. Because there is a small chance that this will
+                 * have a stale manifestId, we update the url in the opened preview tab just in case
+                 * to ensure that the user is redirected to the correct preview build
                  */
                 previewWindow.location.href = this.getPreviewUrl();
               }}

--- a/apps/gatsby/src/Sidebar.js
+++ b/apps/gatsby/src/Sidebar.js
@@ -188,9 +188,7 @@ export default class Sidebar extends React.Component {
       });
     });
 
-    await space.updateEntry(updatedEntry);
-
-    return;
+    return space.updateEntry(updatedEntry);
   }
 
   refreshPreview = async () => {
@@ -212,6 +210,20 @@ export default class Sidebar extends React.Component {
     }
   };
 
+  getPreviewUrl = () => {
+    let {
+      previewUrl,
+      contentSyncUrl,
+    } = this.props.sdk.parameters.installation;
+    const { manifestId } = this.state
+
+    if (contentSyncUrl && manifestId) {
+      previewUrl = `${contentSyncUrl}/gatsby-source-contentful/${manifestId}`;
+    }
+
+    return previewUrl;
+  }
+
   render = () => {
     let {
       contentSyncUrl,
@@ -220,13 +232,9 @@ export default class Sidebar extends React.Component {
       webhookUrl,
       previewWebhookUrl,
     } = this.sdk.parameters.installation;
-    const { slug, manifestId } = this.state
+    const { slug } = this.state
 
-    if (contentSyncUrl && manifestId) {
-      previewUrl = `${contentSyncUrl}/gatsby-source-contentful/${manifestId}`;
-    }
-
-    console.log({ sdk: this.props.sdk });
+    previewUrl = this.getPreviewUrl();
 
     return (
       <div className="extension">
@@ -236,7 +244,14 @@ export default class Sidebar extends React.Component {
               contentSlug={!contentSyncUrl && !!slug && slug}
               previewUrl={previewUrl}
               authToken={authToken}
-              onOpenPreviewButtonClick={this.refreshPreview}
+              onOpenPreviewButtonClick={async ({ previewWindow }) => {
+                await this.refreshPreview();
+                /**
+                 * ensure that the preview tab has the correct manifest id
+                 * just in case the timing was slight off and it was opened with the wrong manifest id
+                 */
+                previewWindow.location = this.getPreviewUrl();
+              }}
             /> :
             <HelpText style={STATUS_STYLE}>
               <Icon icon="Warning" color="negative" style={ICON_STYLE} />


### PR DESCRIPTION
### Summary
We currently have to wait for Contentful to save content before clicking "Open Preview". This uses the Contentful app SDK to implement a way to manually save an entry which allows us to deterministically create a preview build and then ensure the user is routed there.

One small hiccup that I noticed is that adding content to a locale field that was previously entered will cause the UI to show this warning but oddly enough, the UI still seems to be up to date with the correct values. My hunch is that this warning is shown anytime an entry is saved by a means other than the Contentful autosave feature.

![image](https://user-images.githubusercontent.com/21110659/135670599-89e7cd93-dbf5-4a14-8514-47d69653d068.png)

Note that this relies on changes to the `gatsby-cms-extension-base` package. [The PR for that is here](https://github.com/gatsby-inc/mansion/pull/13100)
