### PR TITLE
feat: wait for onsyschange

### DIFF
--- a/apps/gatsby/src/Sidebar.js
+++ b/apps/gatsby/src/Sidebar.js
@@ -200,7 +200,7 @@ export default class Sidebar extends React.Component {
 
     this.setState({ buttonDisabled: true })
 
-    // wait a bit for contentful to save.
+    // Contentful takes a few seconds to save. If we do not wait a bit for this, then the Gatsby preview may be started and finish before any content is even saved on the Contentful side
     await new Promise(resolve => setTimeout(resolve, 3000))
     
     this.refreshPreview();


### PR DESCRIPTION
This PR solves (with bandaids) the contentful onSysChange vs data save timing issue.

1. When pressing open preview the button becomes disabled and a loading indicator appears below it.
2. We wait 3 seconds before doing anything to let Contentful catch up to us
3. We open the Content Sync page with the manifest ID we have
4. We set an interval to recheck the manifest ID every second for 10 seconds.
5. If the ID changes in those 10 seconds, we refresh the Content Sync window with the updated manifest ID.
6. After the ID changes or after 10 seconds the button becomes clickable again.

The initial 3 second wait is required to make sure the incremental build doesn't happen before Contentful saves the entry data (this happens suprisingly often). The rest is a pile of bandaids because Contentful doesn't expose an API to let us know when the data is saved.

Manually saving the data on our own causes other problems:
1. It locks the UI so the user can't do anything until they refresh the page
2. onSysChanged stops firing probably due to the UI being locked so we can't refresh the content sync window if the manifest ID changes.
3. Manually saving doesn't seem to create the right manifest ID.

TODO:

- Use ExtensionUI component instead of this custom Button component in this PR. This will require another PR to mansion.
  - Add disabled state to button with new styles
  - Add new prop to prevent extension UI from opening the previewUrl
- Remove console logs
- Cleanup code