### PR TITLE
Remove previewWebhookUrl and prod build calls.

### DIFF
--- a/apps/gatsby/src/AppConfig/AppConfig.js
+++ b/apps/gatsby/src/AppConfig/AppConfig.js
@@ -286,29 +286,12 @@ export class AppConfig extends React.Component {
           </div>
           <hr className={styles.splitter} />
           <Typography>
-            <Heading>Site Settings</Heading>
+            <Heading>Configure CMS Preview</Heading>
             <Paragraph>Use the Site Settings for your Gatsby Cloud site below.</Paragraph>
-            <TextField
-              name="previewWebhookUrl"
-              id="previewWebhookUrl"
-              labelText="Preview Webhook"
-              value={this.state.previewWebhookUrl}
-              onChange={this.updatePreviewWebhookUrl}
-              onBlur={this.validatePreviewWebhookUrl}
-              className={styles.input}
-              validationMessage={
-                !this.state.validPreviewWebhook
-                  ? urlHelpText
-                  : ""
-              }
-              textInputProps={{
-                type: "text",
-              }}
-            />
             <TextField
               name="webhookUrl"
               id="webhookUrl"
-              labelText="Builds Webhook"
+              labelText="Preview Webhook"
               value={this.state.webhookUrl}
               onChange={this.updateWebhookUrl}
               onBlur={this.validateWebhookUrl}

--- a/apps/gatsby/src/Sidebar.js
+++ b/apps/gatsby/src/Sidebar.js
@@ -62,36 +62,8 @@ export default class Sidebar extends React.Component {
     });
   }
 
-  /**
-   * lastPublishedDateTime is used to track when the built in Contentful publish button is clicked
-   * and then kick off production builds of the Gatsby site accordingly
-   */
-  maybeStartProductionBuild = (content) => {
-    const { webhookUrl, authToken } = this.sdk.parameters.installation;
-    const { lastPublishedDateTime } = this.state;
-
-    /**
-     * if these timestamps are equal than the content has not been published OR has not been
-     * re-published after changes to the content have been made
-     */
-    if (!lastPublishedDateTime || lastPublishedDateTime === content.publishedAt) {
-      return;
-    }
-
-    if (!webhookUrl) {
-      /**
-       * @todo add this warning to the UI
-       */
-      console.warn('Warning: Gatsby production build not started since no webhookUrl has been configured.');
-      return;
-    }
-
-    callWebhook(webhookUrl, authToken);
-  }
-
   onSysChanged = (content) => {
     this.setManifestId(content);
-    this.maybeStartProductionBuild(content);
     this.buildSlug();
   };
 
@@ -166,13 +138,10 @@ export default class Sidebar extends React.Component {
   refreshPreview = () => {
     const {
       webhookUrl,
-      previewWebhookUrl,
       authToken
     } = this.sdk.parameters.installation;
 
-    if (previewWebhookUrl) {
-      callWebhook(previewWebhookUrl, authToken);
-    } else if (webhookUrl) {
+    if (webhookUrl) {
       callWebhook(webhookUrl, authToken);
     } else {
       console.warn(`Please add a Preview Webhook URL to your Gatsby Cloud App settings.`)
@@ -233,15 +202,12 @@ export default class Sidebar extends React.Component {
     }, 10000)
 }
 
-
-
   render = () => {
     let {
       contentSyncUrl,
       authToken,
       previewUrl,
       webhookUrl,
-      previewWebhookUrl,
     } = this.sdk.parameters.installation;
     const { slug } = this.state
 
@@ -250,7 +216,7 @@ export default class Sidebar extends React.Component {
     return (
       <div className="extension">
         <div className="flexcontainer">
-          {(previewWebhookUrl || webhookUrl) ?
+          {(webhookUrl) ?
               <>
                 <ExtensionUI
                   disabled={this.state.buttonDisabled}


### PR DESCRIPTION
Shortcut: https://app.shortcut.com/gatsbyjs/story/39577/content-sync-combine-webhook-url-and-preview-webhook-url-fields

 - remove call to trigger production build (removing a need for a separate prod builds webhook
 - remove `previewWebhookUrl` field. the `webhookUrl` field got renamed to Preview Webhook URL, and behaves as such.
 - As per @jacksellwood mention, renamed "Site Settings" in app config to "Configure CMS Preview"

Note: in gatsby contenful app, `Gatsby Cloud Dev App` has been modified to use these changes.

![Screen Shot 2021-10-08 at 9 40 41 AM](https://user-images.githubusercontent.com/12630992/136593876-92e5790e-f53b-4a50-8969-90ad6c88ca05.png)

![Screen Shot 2021-10-08 at 9 41 29 AM](https://user-images.githubusercontent.com/12630992/136593872-5fc88037-dfec-4d2d-8386-44f6429a8fd3.png)
