### PR TITLE
feat: auto add preview button to content types

### DIFF
--- a/apps/gatsby/src/AppConfig/AppConfig.js
+++ b/apps/gatsby/src/AppConfig/AppConfig.js
@@ -21,13 +21,31 @@ function editorInterfacesToEnabledContentTypes(eis, appId) {
     .filter(ctId => typeof ctId === "string" && ctId.length > 0);
 }
 
-export function enabledContentTypesToTargetState(currentState, contentTypes, enabledContentTypes) {
+export function enabledContentTypesToTargetState(
+  currentState,
+  contentTypes,
+  enabledContentTypes,
+  usingContentSync
+) {
   return {
     EditorInterface: contentTypes.reduce((acc, ct) => {
-      const ctCurrentStateSidebar = currentState?.EditorInterface[ct.sys.id]?.sidebar;
+      if (usingContentSync) {
+        return {
+          ...acc,
+          // if content sync is being used
+          // auto add our preview button to each content type
+          // at the top of the sidebar
+          [ct.sys.id]: { sidebar: { position: 0 } }
+        }
+      }
+
+      const ctCurrentStateSidebar = 
+        currentState?.EditorInterface[ct.sys.id]?.sidebar;
+
       const ctEditorInterface = ctCurrentStateSidebar
         ? { sidebar: ctCurrentStateSidebar }
         : { sidebar: { position: 3 } };
+
       return {
         ...acc,
         [ct.sys.id]: enabledContentTypes.includes(ct.sys.id) ? ctEditorInterface : {},
@@ -148,7 +166,8 @@ export class AppConfig extends React.Component {
       targetState: enabledContentTypesToTargetState(
         currentState,
         contentTypes,
-        enabledContentTypes
+        enabledContentTypes,
+        !!contentSyncUrl
       ),
     };
   };


### PR DESCRIPTION
This PR adds a check during app.onConfigure to enable the "Open Preview" button for all content types if Content Sync is being used. This is for https://app.shortcut.com/gatsbyjs/story/39663/when-setting-up-content-sync-with-contentful-auto-add-open-preview-to-all-content-types. I'm opening this PR before Lana, Jack, and Raisa get to this to make it easier for me to add content sync support to gatsbyjs.com. These changes may be temporary or they may be final depending on what those three decide when working on that ticket ☝️